### PR TITLE
LA-9-View-All-Books

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>kotlin-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/jar/us/librarymanagementsystemapi/BookController.kt
+++ b/src/main/kotlin/jar/us/librarymanagementsystemapi/BookController.kt
@@ -20,4 +20,12 @@ class BookController(private val bookService: BookService) {
         val savedBook = bookService.addBook(book)
         return savedBook.toResponse()
     }
+
+    // New retrieveAllBooks method
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    fun retrieveAllBooks(): List<BookResponse> {
+        val books = bookService.retrieveAllBooks()
+        return books.map { it.toResponse() }
+    }
 }

--- a/src/main/kotlin/jar/us/librarymanagementsystemapi/service/BookService.kt
+++ b/src/main/kotlin/jar/us/librarymanagementsystemapi/service/BookService.kt
@@ -16,4 +16,9 @@ class BookService(private val bookRepository: BookRepository) {
         }
         return bookRepository.save(book)
     }
+
+    fun retrieveAllBooks(): List<Book> {
+        return bookRepository.findAll()
+    }
+
 }

--- a/src/test/kotlin/jar/us/librarymanagementsystemapi/book/AbstractBookControllerTest.kt
+++ b/src/test/kotlin/jar/us/librarymanagementsystemapi/book/AbstractBookControllerTest.kt
@@ -1,0 +1,32 @@
+package jar.us.librarymanagementsystemapi.book
+
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jar.us.librarymanagementsystemapi.repository.BookRepository
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+abstract class AbstractBookControllerTest {
+    @Autowired
+    protected lateinit var mockMvc: MockMvc
+
+    @Autowired
+    protected lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    protected lateinit var bookRepository: BookRepository
+
+    @BeforeEach
+    fun setup() {
+        // Clear the book repository before each test to ensure clean database state
+        bookRepository.deleteAll()
+    }
+}

--- a/src/test/kotlin/jar/us/librarymanagementsystemapi/book/AddBookTest.kt
+++ b/src/test/kotlin/jar/us/librarymanagementsystemapi/book/AddBookTest.kt
@@ -1,0 +1,108 @@
+package jar.us.librarymanagementsystemapi.book
+
+import jar.us.librarymanagementsystemapi.schema.BookRequest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import kotlin.test.Test
+
+class AddBookTest : AbstractBookControllerTest() {
+
+
+    @Test
+    fun `should successfully add a new book`() {
+        val bookRequest = BookRequest(
+            title = "The Pragmatic Programmer",
+            author = "Andrew Hunt",
+            isbn = "9780135957059",
+            publicationYear = 1999,
+            genre = "Software Development",
+            totalCopies = 15,
+            availableCopies = 15
+        )
+
+        mockMvc.perform(
+            post("/api/books")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bookRequest))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.title").value("The Pragmatic Programmer"))
+            .andExpect(jsonPath("$.author").value("Andrew Hunt"))
+            .andExpect(jsonPath("$.isbn").value("9780135957059"))
+            .andExpect(jsonPath("$.totalCopies").value(15))
+            .andExpect(jsonPath("$.availableCopies").value(15))
+    }
+
+    @Test
+    fun `should return 400 when adding a book with duplicate ISBN`() {
+        val bookRequest = BookRequest(
+            title = "Test Book",
+            author = "Test Author",
+            isbn = "1234567890123",
+            publicationYear = 2020,
+            genre = "Test Genre",
+            totalCopies = 10,
+            availableCopies = 10
+        )
+
+        // Save the first book
+        mockMvc.perform(
+            post("/api/books")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bookRequest))
+        )
+            .andExpect(status().isCreated)
+
+        // Try saving another book with the same ISBN
+        mockMvc.perform(
+            post("/api/books")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bookRequest))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("ISBN '1234567890123' already exists"))
+    }
+
+    @Test
+    fun `should return 400 when adding a book with missing required fields`() {
+        val incompleteRequest = mapOf(
+            "title" to "Incomplete Book" // Missing 'author', 'isbn', 'totalCopies', and 'availableCopies'
+        )
+
+        mockMvc.perform(
+            post("/api/books")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(incompleteRequest))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.error").value("Missing or null value for field 'author', which is required.")) // Sample validation message
+    }
+
+    @Test
+    fun `should return 400 when adding a book with invalid data`() {
+        val invalidRequest = BookRequest(
+            title = "", // Invalid: empty title
+            author = "Valid Author",
+            isbn = "12345", // Invalid: ISBN too short
+            publicationYear = 2023,
+            genre = "Genre",
+            totalCopies = -1, // Invalid: negative copies
+            availableCopies = -5 // Invalid: negative copies
+        )
+
+        mockMvc.perform(
+            post("/api/books")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRequest))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").exists()) // Check if error message exists
+
+            .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString("Title is required")))
+            .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString("Available copies must be zero or positive")))
+            .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString("Total copies must be zero or positive")))
+    }
+}

--- a/src/test/kotlin/jar/us/librarymanagementsystemapi/book/RetrieveBooksTest.kt
+++ b/src/test/kotlin/jar/us/librarymanagementsystemapi/book/RetrieveBooksTest.kt
@@ -1,0 +1,45 @@
+package jar.us.librarymanagementsystemapi.book
+
+import jar.us.librarymanagementsystemapi.domain.Book
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import kotlin.test.Test
+
+class RetrieveBooksTest : AbstractBookControllerTest() {
+
+    @Test
+    fun `should return empty array when no books exist`() {
+        mockMvc.perform(get("/api/books"))
+            .andExpect(status().isOk)
+            .andExpect(content().json("[]"))
+    }
+
+    @Test
+    fun `should return list of books when books exist`() {
+        val book1 = Book(
+            title = "Clean Code",
+            author = "Robert C. Martin",
+            isbn = "9780132350884",
+            publicationYear = 2008,
+            genre = "Software Development",
+            totalCopies = 10,
+            availableCopies = 8
+        )
+        val book2 = Book(
+            title = "Effective Java",
+            author = "Joshua Bloch",
+            isbn = "9780134685991",
+            publicationYear = 2017,
+            genre = "Software Development",
+            totalCopies = 5,
+            availableCopies = 5
+        )
+        bookRepository.saveAll(listOf(book1, book2))
+
+        mockMvc.perform(get("/api/books"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].title").value("Clean Code"))
+            .andExpect(jsonPath("$[1].title").value("Effective Java"))
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
Introduced integration tests for adding and retrieving books, ensuring validation on required fields, duplicate ISBN handling, and invalid data. Added an H2 in-memory database for testing, along with a base test class for shared setup. Updated `BookController` and `BookService` with `retrieveAllBooks` method to support fetching all books.