### PR TITLE
Add sample data population on application startup

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,3 @@
+# Development profile configuration for sample data loading
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,3 @@ spring.datasource.username=postgres
 spring.datasource.password=postgres
 
 spring.jpa.hibernate.ddl-auto=create-drop
-spring.sql.init.mode=always
-spring.jpa.defer-datasource-initialization=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.username=postgres
 spring.datasource.password=postgres
 
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,31 @@
+-- Sample data for Library Management System
+INSERT INTO book (title, author, isbn, publication_year, genre, total_copies, available_copies) VALUES
+('The Clean Code', 'Robert C. Martin', '9780132350884', 2008, 'Programming', 10, 8),
+('Effective Java', 'Joshua Bloch', '9780134685991', 2017, 'Programming', 5, 3),
+('Spring in Action', 'Craig Walls', '9781617294945', 2018, 'Programming', 8, 6),
+('Design Patterns', 'Gang of Four', '9780201633612', 1994, 'Programming', 6, 4),
+('Clean Architecture', 'Robert C. Martin', '9780134494166', 2017, 'Software Architecture', 7, 5),
+
+('The Pragmatic Programmer', 'David Thomas', '9780135957059', 2019, 'Programming', 12, 10),
+('Kotlin in Action', 'Dmitry Jemerov', '9781617293290', 2017, 'Programming', 4, 2),
+('You Don''t Know JS', 'Kyle Simpson', '9781491924464', 2015, 'Programming', 15, 12),
+('Refactoring', 'Martin Fowler', '9780134757599', 2018, 'Programming', 9, 7),
+('Head First Design Patterns', 'Eric Freeman', '9780596007126', 2004, 'Programming', 8, 6),
+
+('The Mythical Man-Month', 'Frederick P. Brooks Jr.', '9780201835953', 1995, 'Software Engineering', 5, 3),
+('Code Complete', 'Steve McConnell', '9780735619678', 2004, 'Software Engineering', 6, 4),
+('The Art of Computer Programming', 'Donald E. Knuth', '9780201896831', 1997, 'Computer Science', 3, 1),
+('Introduction to Algorithms', 'Thomas H. Cormen', '9780262033848', 2009, 'Computer Science', 10, 8),
+('System Design Interview', 'Alex Xu', '9780578973831', 2020, 'Software Engineering', 7, 5),
+
+('Dune', 'Frank Herbert', '9780441172719', 1965, 'Science Fiction', 12, 9),
+('The Hobbit', 'J.R.R. Tolkien', '9780547928227', 1937, 'Fantasy', 15, 11),
+('1984', 'George Orwell', '9780451524935', 1949, 'Dystopian Fiction', 20, 18),
+('To Kill a Mockingbird', 'Harper Lee', '9780060935467', 1960, 'Classic Literature', 10, 8),
+('The Great Gatsby', 'F. Scott Fitzgerald', '9780743273565', 1925, 'Classic Literature', 8, 6),
+
+('Sapiens', 'Yuval Noah Harari', '9780062316097', 2014, 'History', 14, 12),
+('Educated', 'Tara Westover', '9780399590504', 2018, 'Memoir', 9, 7),
+('The Lean Startup', 'Eric Ries', '9780307887894', 2011, 'Business', 11, 9),
+('Atomic Habits', 'James Clear', '9780735211292', 2018, 'Self-Help', 16, 13),
+('The Power of Now', 'Eckhart Tolle', '9781577314806', 1997, 'Philosophy', 7, 5);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- Sample data for Library Management System
 INSERT INTO book (title, author, isbn, publication_year, genre, total_copies, available_copies) VALUES
-('The Clean Code', 'Robert C. Martin', '9780132350884', 2008, 'Programming', 10, 8),
+('Clean Code', 'Robert C. Martin', '9780132350884', 2008, 'Programming', 10, 8),
 ('Effective Java', 'Joshua Bloch', '9780134685991', 2017, 'Programming', 5, 3),
 ('Spring in Action', 'Craig Walls', '9781617294945', 2018, 'Programming', 8, 6),
 ('Design Patterns', 'Gang of Four', '9780201633612', 1994, 'Programming', 6, 4),


### PR DESCRIPTION
- Create data.sql with 25 sample books across different genres
- Include programming books (Clean Code, Effective Java, Spring in Action, etc.)
- Add classic literature (1984, To Kill a Mockingbird, The Great Gatsby)
- Include non-fiction (Sapiens, Atomic Habits, The Lean Startup)
- Configure Spring Boot to load data.sql on startup
- Set spring.sql.init.mode=always and spring.jpa.defer-datasource-initialization=true
- Provides ready-to-use data for testing and demonstration

🤖 Generated with [Claude Code](https://claude.ai/code)